### PR TITLE
Update untracked files command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,16 @@ The script includes information like:
 Additionally, the script allows you to toggle the display of individual features.
 
 ## Example
+
 ![Example of Git status bar in iTerm2](/example.png?raw=true)
+
+## Requirements
+
+1. [Bash](https://www.gnu.org/software/bash/)
+
+2. [Awk](https://www.gnu.org/software/gawk/manual/gawk.html)
+
+3. [Sed](https://www.gnu.org/software/sed/manual/sed.html)
 
 ## Installation
 

--- a/bashrc_snippet.sh
+++ b/bashrc_snippet.sh
@@ -62,7 +62,7 @@ get_git_info() {
 
 		if [ "$GIT_SHOW_UNTRACKED_FILES" = true ]; then
 			local untracked_files
-			untracked_files=$(git ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d '[:space:]')
+			untracked_files=$(git status -u 2>/dev/null | awk '/^  \(use "git add/,/^nothing added/{if (!/^  \(use "git add/ && !/^nothing added/ && !/^$/) print}' | sed '/^$/d' | wc -l | tr -d '[:space:]')
 			if [ "$untracked_files" != "0" ]; then
 				output+="✚$untracked_files "
 			fi


### PR DESCRIPTION
Previous untracked files command only looked at current working directory

This updates the command to list number of files for entire repo. However it does also introduce the requirement for `awk` and `sed` since we need to do some manipulation to the output of the `git` command